### PR TITLE
Prevent file path leakage in debug message

### DIFF
--- a/lws_core/logging_setup.py
+++ b/lws_core/logging_setup.py
@@ -83,7 +83,9 @@ def setup_logging(log_level=logging.DEBUG, log_file=None, json_log_file=None):
     }
 
     logging.config.dictConfig(logging_config)
-    logging.debug("🔎 Logging to console, and additional JSON logging to file {}".format(json_log_file if json_log_file else "not configured"))
+    # Extract only the filename to avoid leaking the current working directory in logs
+    json_log_filename = os.path.basename(json_log_file) if json_log_file else "not configured"
+    logging.debug("🔎 Logging to console, and additional JSON logging to file %s", json_log_filename)
 
 
 # Initialize logging when module is imported


### PR DESCRIPTION
### FabGPT — code quality

**File:** `lws_core/logging_setup.py`

**Rationale:** The debug message in `setup_logging` currently prints the `json_log_file` argument directly, which exposes the full absolute path (including the current working directory) in logs. Since the function already calculates the absolute paths internally, the debug message should only display the filename to avoid leaking sensitive directory information.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `06c7d8e5f8212ab8` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"06c7d8e5f8212ab8","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":49.94,"prompt_sha":"079d21ee1c7a120f","triage":"INFO"} -->