### PR TITLE
fix: sync version to 1.4.1 (latest release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**Version:** 1.1.0
+**Version:** 1.4.1
 
 [![GitHub](https://img.shields.io/github/license/fabriziosalmi/lws)](https://github.com/fabriziosalmi/lws/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/)

--- a/lws_core/__init__.py
+++ b/lws_core/__init__.py
@@ -5,7 +5,7 @@ This module contains core utilities for the LWS (Linux Web Services) CLI tool.
 It provides configuration management, logging, SSH execution, and Proxmox command utilities.
 """
 
-__version__ = '1.1.0'
+__version__ = '1.4.1'
 
 # Import logging first (no dependencies)
 from .logging_setup import setup_logging, JsonFormatter


### PR DESCRIPTION
## What
The README header and `lws_core.__version__` still reported **1.1.0**, but the latest released tag is **v1.4.1**. Since `lws.py` exposes the CLI version via `@click.version_option(version=__version__)`, `lws --version` reported a stale value.

## Fix
- `README.md` header: `**Version:** 1.1.0` → `1.4.1`
- `lws_core/__init__.py`: `__version__ = '1.1.0'` → `'1.4.1'`

## Verification
AST parse confirms `__version__ == 1.4.1`; no `1.1.0` remains in any source file. The OpenAPI `info.version` in `api.py` (`"1.0.0"`) is the API-contract version, intentionally left unchanged.

> Follow-up (out of scope): `lws_core/__pycache__/*.pyc` is tracked in the repo — bytecode caches shouldn't be versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)