### PR TITLE
privacy: link the shared privacy notice + meta-CSP

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'">
     <meta name="description" content="{{ page.title }} - LWS Documentation">
     <title>{{ page.title }} - LWS Documentation</title>
 
@@ -89,6 +90,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2024 LWS. Released under the MIT License.</p>
+                <p><a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a></p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
This site had **no privacy notice**. It now links the canonical one published once for every project site on this host:

### 🔗 https://fabriziosalmi.github.io/privacy

That notice is accurate here as-is: same publisher, same host (GitHub Pages), no cookies, no analytics. One document to maintain instead of a copy per repository.

## Changes
- **Footer** — a `Privacy & legal` link.
- **meta-CSP** — `default-src 'self'`.

## Verified in a browser
| Check | Result |
|---|---|
| Third-party origins | **`[]` — zero** |
| Privacy link | ✅ present |
| CSP violations | **none** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)