### PR TITLE
privacy: add the notice link and CSP to the home page as well

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,13 @@
 
     <title>LWS - Linux Web Services | Proxmox Container Management</title>
 
+    <!--
+      Same policy as _layouts/default.html, which covers the pages/ collection.
+      This file has no front matter, so Jekyll copies it verbatim and the layout
+      never applies to it - the tag has to be repeated here.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'">
+
     <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/fonts.css">
 </head>
@@ -308,6 +315,7 @@
                     <div class="footer-column">
                         <h4>Legal</h4>
                         <a href="https://github.com/fabriziosalmi/lws/blob/main/LICENSE" target="_blank">MIT License</a>
+                        <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal notice</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Follow-up to #26, which did **not** fully land.

## What I got wrong

#26 edited `docs/_layouts/default.html`, assuming a Jekyll layout covers every page. It does not cover `docs/index.html` — that file is hand-written HTML **with no front matter**, so Jekyll copies it verbatim and never applies a layout.

Verified live after #26 merged:

| page | privacy link | CSP |
|---|---|---|
| `/lws/` (home) | ❌ | ❌ |
| `/lws/pages/getting-started.html` | ✅ | ✅ |
| `/lws/pages/architecture.html` | ✅ | ✅ |
| `/lws/pages/cli-reference.html` | ✅ | ✅ |

The six `docs/_pages/*.md` documents are reached because `_config.yml` declares them as a collection and defaults them to `layout: default`. The home page — the one people actually land on — was the gap.

## The fix

The CSP is **character-for-character identical** to the layout's, not a tighter variant. The page has 0 inline styles, 0 inline handlers and 0 inline scripts, so `'unsafe-inline'` isn't needed for anything it does today — but `main.js` drives layout through 14 `.style` assignments, and this site can't be opened in my browser tooling to confirm nothing regresses. Identical policies cost nothing in privacy terms (neither allows any third-party origin) and keep the seven pages coherent.

The link goes in the existing **Legal** footer column, next to the MIT licence.

## Note on `vibe-check`

It is red on this branch, as it is on `main` — the score is **-3323 on main** from 251 pre-existing violations. My change adds one `[MNT02] Very Long Line` (-10 pts): a CSP policy is inherently one long line.