### PR TITLE
fix(docs): rel="noopener" sui link esterni con target="_blank"

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,7 @@
                 <a href="getting-started.html">Getting Started</a>
                 <a href="cli-reference.html">CLI</a>
                 <a href="api-reference.html">API</a>
-                <a href="https://github.com/fabriziosalmi/lws" target="_blank">GitHub</a>
+                <a href="https://github.com/fabriziosalmi/lws" target="_blank" rel="noopener">GitHub</a>
             </div>
         </div>
     </nav>
@@ -49,8 +49,8 @@
             <div class="sidebar-section">
                 <h3>Community</h3>
                 <a href="contributing.html">Contributing</a>
-                <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank">Issues</a>
-                <a href="https://github.com/fabriziosalmi/lws/discussions" target="_blank">Discussions</a>
+                <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank" rel="noopener">Issues</a>
+                <a href="https://github.com/fabriziosalmi/lws/discussions" target="_blank" rel="noopener">Discussions</a>
             </div>
         </aside>
 
@@ -78,13 +78,13 @@
                     </div>
                     <div class="footer-column">
                         <h4>Community</h4>
-                        <a href="https://github.com/fabriziosalmi/lws" target="_blank">GitHub</a>
-                        <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank">Issues</a>
+                        <a href="https://github.com/fabriziosalmi/lws" target="_blank" rel="noopener">GitHub</a>
+                        <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank" rel="noopener">Issues</a>
                         <a href="contributing.html">Contributing</a>
                     </div>
                     <div class="footer-column">
                         <h4>Legal</h4>
-                        <a href="https://github.com/fabriziosalmi/lws/blob/main/LICENSE" target="_blank">MIT License</a>
+                        <a href="https://github.com/fabriziosalmi/lws/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
                     </div>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
                 <a href="#features">Features</a>
                 <a href="#quickstart">Quick Start</a>
                 <a href="#docs">Docs</a>
-                <a href="https://github.com/fabriziosalmi/lws" target="_blank">GitHub</a>
+                <a href="https://github.com/fabriziosalmi/lws" target="_blank" rel="noopener">GitHub</a>
             </div>
         </div>
     </nav>
@@ -308,13 +308,13 @@
                     </div>
                     <div class="footer-column">
                         <h4>Community</h4>
-                        <a href="https://github.com/fabriziosalmi/lws" target="_blank">GitHub</a>
-                        <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank">Issues</a>
+                        <a href="https://github.com/fabriziosalmi/lws" target="_blank" rel="noopener">GitHub</a>
+                        <a href="https://github.com/fabriziosalmi/lws/issues" target="_blank" rel="noopener">Issues</a>
                         <a href="pages/contributing.html">Contributing</a>
                     </div>
                     <div class="footer-column">
                         <h4>Legal</h4>
-                        <a href="https://github.com/fabriziosalmi/lws/blob/main/LICENSE" target="_blank">MIT License</a>
+                        <a href="https://github.com/fabriziosalmi/lws/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
                         <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal notice</a>
                     </div>
                 </div>


### PR DESCRIPTION
Aggiunge `rel="noopener"` alle ancore con `target="_blank"` che puntano a un host **terzo**.

**Cosa cambia** — 10 link, tutti verso `github.com`:
- `docs/index.html` (4)
- `docs/_layouts/default.html` (6) — il layout serve anche le altre pagine

**Cosa NON cambia:** i link relativi (aprono una pagina di questo sito, nessun rischio) e le ancore che avevano già un `rel`. Solo attributi HTML: nessuna modifica a stile, testo o struttura.

**Nota onesta sulla priorità.** Dal 2021 ogni browser aggiornato sottintende `noopener` su `target="_blank"` (Chrome 88, Firefox 79, Safari 12.1): il tabnabbing via `window.opener` non è raggiungibile lì, e i destinatari qui sono `github.com`. Quindi questa non è una falla che si chiude — è igiene che rende esplicito il comportamento e zittisce i linter.

Verificato con la sonda read-only di fabgpt-scout sui file modificati: nessun link esterno `_blank` scoperto rimasto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
