### PR TITLE
fix(api): refuse to start without a real API key, and default to loopback

### DIFF
--- a/api.py
+++ b/api.py
@@ -11,6 +11,7 @@ import subprocess
 import yaml
 import logging
 import sys
+import hmac
 import re
 from functools import wraps
 import shlex  # Import shlex for safe command splitting
@@ -54,8 +55,40 @@ allowed_origins = API_CONFIG.get('allowed_origins', '*') # Default to allow all 
 # Example: allowed_origins = ["http://localhost:8000", "null"]
 CORS(app, origins=allowed_origins) # Apply CORS settings
 
+# The API drives lws, which runs pct and ssh as root on every configured
+# Proxmox host. An unauthenticated instance is therefore a root-equivalent
+# control plane, so a missing or placeholder key is a refusal to start rather
+# than a warning: a warning scrolls past, and the previous behaviour left every
+# protected endpoint open when the key was absent.
+PLACEHOLDER_API_KEYS = {
+    "my-secure-api-key",
+    "your-secure-api-key",
+    "changeme",
+    "change-me",
+}
+
 if not API_KEY:
-    logging.warning("API key is not set in config.yaml. API will be insecure.")
+    logging.critical(
+        "api_key is not set in config.yaml. Refusing to start: without it every "
+        "endpoint would be unauthenticated, and they run pct and ssh as root on "
+        "your Proxmox hosts. Generate one with: "
+        "python3 -c 'import secrets; print(secrets.token_urlsafe(32))'"
+    )
+    sys.exit(1)
+
+if API_KEY in PLACEHOLDER_API_KEYS:
+    logging.critical(
+        "api_key is still the placeholder shipped in this repository, so it is "
+        "public. Refusing to start. Generate one with: "
+        "python3 -c 'import secrets; print(secrets.token_urlsafe(32))'"
+    )
+    sys.exit(1)
+
+if len(API_KEY) < 32:
+    logging.warning(
+        "api_key is shorter than 32 characters. This key is the only thing "
+        "between the network and root on your Proxmox hosts."
+    )
 
 # Configure logging
 log_level_str = API_CONFIG.get('log_level', 'INFO').upper()
@@ -95,11 +128,12 @@ def sanitize_input(input_value, max_length=255):
 def require_api_key(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        if API_KEY: # Only enforce if API_KEY is set
-            provided_key = request.headers.get('X-API-Key')
-            if not provided_key or provided_key != API_KEY:
-                logging.warning(f"Unauthorized access attempt from {request.remote_addr}")
-                abort(401, description="Unauthorized: Invalid or missing API key.")
+        # Enforced unconditionally: startup refuses to run without a real key,
+        # so there is no configuration in which this check should be skipped.
+        provided_key = request.headers.get('X-API-Key')
+        if not provided_key or not hmac.compare_digest(provided_key, API_KEY):
+            logging.warning(f"Unauthorized access attempt from {request.remote_addr}")
+            abort(401, description="Unauthorized: Invalid or missing API key.")
         return f(*args, **kwargs)
     return decorated_function
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,14 @@ minimum_resources:
   memory_mb: 512
 
 # API configuration
-api_key: "my-secure-api-key"  # Replace with a strong, random API key
+# The API server runs lws, which executes pct and ssh as root on every host in
+# `regions` below. Treat this key as root credentials for the whole estate.
+# Generate one: python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+# The server refuses to start while this is empty or still the placeholder.
+api_key: ""
 api:
-  host: "0.0.0.0"      # Listen on all interfaces
+  host: "127.0.0.1"    # Loopback. Use a private address or a reverse proxy that
+                       # authenticates before exposing this beyond the machine.
   port: 8080           # Default port for the API server
   debug: false         # Set to true for development only
   log_level: "INFO"    # Log level (DEBUG, INFO, WARNING, ERROR)


### PR DESCRIPTION
## The problem

The API server runs `lws`, which executes `pct` and `ssh` as root on every host in `regions`. An unauthenticated instance is a root-equivalent control plane for the whole estate.

Three things combined to make that the likely outcome of following the quick start:

1. **`require_api_key` was fail-open.** `if API_KEY:` meant that an absent or empty key skipped the check entirely, leaving every protected endpoint open. The only signal was one `logging.warning` at startup. Removing the placeholder intending to set a key later produced a fully open API.
2. **The shipped `config.yaml` had `host: "0.0.0.0"`**, overriding the safe `127.0.0.1` default the code already had. The same port also serves the web UI at `/` and the Swagger map at `/api/v1/docs`.
3. **The shipped key was the placeholder `my-secure-api-key`**, published in this repository.

## The change

- Startup **refuses** an empty key and **refuses** a known placeholder, so `require_api_key` can enforce unconditionally
- Key comparison is now constant-time (`hmac.compare_digest`)
- A key shorter than 32 characters **warns** rather than blocks: it is the documented recommendation, not something the server can insist on without breaking existing deployments
- `config.yaml` now ships `api_key: ""` and `host: "127.0.0.1"`, with the reasoning next to them

## Verified

| `api_key` | Result |
|---|---|
| empty | exit 1, refuses |
| `my-secure-api-key` | exit 1, refuses |
| short (6 chars) | starts, warns |
| 38 chars | starts, silent |

## Note on upgrades

An existing deployment that still uses the placeholder key will stop starting, with an error saying exactly what to generate. That is the intent: that key is public.