### PR TITLE
ci: raise the tested Python floor to 3.10, and test the version we ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # README advertises "Python 3.6 or higher"; Dockerfile targets 3.11.
-        # We test the currently-maintained CPython line that setup-python can provide.
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # Floor is 3.10: Python 3.9 reached end of life in October 2025, and the
+        # dependencies this project pins have followed. requests 2.33 and later
+        # and pytest 8.2 and later both declare Requires-Python >=3.10, so a 3.9
+        # entry here does not test an old Python, it blocks every update.
+        # Ceiling is 3.14, which is what the Dockerfile ships: the version this
+        # project actually runs in production was not being tested at all.
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ LWS is a command-line interface (CLI) tool designed to simplify the management o
 
 ### Prerequisites
 
-- Python 3.6 or higher
+- Python 3.10 or higher (the Docker image ships 3.14)
 - Proxmox Virtual Environment 6.x or higher
 - SSH access to Proxmox hosts
 - The following Python packages:


### PR DESCRIPTION
The matrix tested 3.9 through 3.13. Neither end was right.

## The floor

Python 3.9 reached end of life in October 2025 and the ecosystem has followed. `requests` 2.33 and later and `pytest` 8.2 and later both declare `Requires-Python >=3.10`, so the 3.9 job cannot install them:

```
ERROR: Ignored the following versions that require a different python version:
       2.33.0 Requires-Python >=3.10; ... 2.34.2 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement requests<3.0.0,>=2.34.2
```

That entry was not testing an old Python. It was blocking updates: after rebasing the open Dependabot pull requests onto current main, the ones that still fail, fail only on `py3.9`, and one of them is a `requests` bump.

## The ceiling

The Dockerfile now ships `python:3.14-slim`, and 3.14 was not in the matrix. The interpreter this project actually runs in production was the one version nobody tested. It is in now.

## The README

It claimed "Python 3.6 or higher". That has not been true for years, and 3.6 has been end of life since December 2021. It now states the floor and names what the image ships.

## Worth a second opinion

Dropping 3.9 means Debian 11 oldstable, which ships 3.9, can no longer run this from a plain `pip install -r requirements.txt`. Proxmox VE 8 is Debian 12 with Python 3.11, so the deployment target this project exists for is unaffected. If you would rather keep 3.9 working, the alternative is to cap `requests` and `pytest` below their 3.10 floors, which means declining security updates to keep an end-of-life interpreter: I would not, but it is your call and reverting this is one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
