### PR TITLE
build(deps): raise pytest to 9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ flask-cors>=6.0.5,<7.0.0
 tqdm>=4.66.2,<5.0.0 # For progress bars in lws.py
 
 # Testing dependencies
-pytest>=7.4.0,<8.0.0
+pytest>=9.1.1,<10.0.0
 pytest-cov>=7.1.0,<8.0.0
 pytest-mock>=3.15.1,<4.0.0


### PR DESCRIPTION
The cap at `<8.0.0` predates #32: pytest 8.2 and later declare `Requires-Python >=3.10`, so with 3.9 in the matrix this dependency could not move at all.

Dependabot's own pull request for this (#24) was closed when its branch went stale rather than rebased onto the new floor, so this makes the same bump directly.

Verified locally on Python 3.12 before opening:

```
98 passed in 4.36s
TOTAL   265   10   92   6   96%
```

Coverage is unchanged and nothing in the suite uses an API pytest 9 removed. CI covers 3.10 through 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)