### PR TITLE
build: declare the supported Python versions once, and check the three copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Floor is 3.10: Python 3.9 reached end of life in October 2025, and the
-        # dependencies this project pins have followed. requests 2.33 and later
-        # and pytest 8.2 and later both declare Requires-Python >=3.10, so a 3.9
-        # entry here does not test an old Python, it blocks every update.
-        # Ceiling is 3.14, which is what the Dockerfile ships: the version this
-        # project actually runs in production was not being tested at all.
+        # Kept in step with `requires-python` in pyproject.toml and with the
+        # Dockerfile by tests/test_python_support.py, which fails if the three
+        # disagree. Change the floor there, not here.
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ LWS is a command-line interface (CLI) tool designed to simplify the management o
 
 ### Prerequisites
 
-- Python 3.10 or higher (the Docker image ships 3.14)
+- Python 3.10 or higher. The supported range is declared once, as `requires-python` in `pyproject.toml`, and the CI matrix and the Docker image are checked against it. The published image ships 3.14.
 - Proxmox Virtual Environment 6.x or higher
 - SSH access to Proxmox hosts
 - The following Python packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+# Packaging metadata for LWS.
+#
+# This file exists mainly for one line: `requires-python`. Until it was added,
+# nothing in the repository stated which Python versions are supported. The
+# README said "3.6 or higher" (untrue for years), the CI matrix said 3.9 to
+# 3.13, and the Dockerfile shipped 3.14. Every dependency bump reopened the
+# question, and the answer had to be reconstructed from three files that
+# disagreed.
+#
+# tests/test_python_support.py checks that this file, the CI matrix and the
+# Dockerfile still agree, so the three cannot drift apart again.
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lws"
+version = "1.4.1"
+description = "Linux Web Services: a CLI and REST API for managing Proxmox VE hosts, VMs and LXC containers"
+readme = "README.md"
+license = { file = "LICENSE" }
+authors = [{ name = "Fabrizio Salmi" }]
+keywords = ["proxmox", "lxc", "virtualization", "cli", "infrastructure"]
+
+# The floor is a policy, not a per-bump judgement: LWS supports the CPython
+# versions upstream still supports, and drops one as it reaches end of life.
+# Python 3.9 reached end of life in October 2025, and the ecosystem followed:
+# requests 2.33 and later and pytest 8.2 and later declare Requires-Python
+# >=3.10, so a 3.9 entry blocked updates rather than testing an old runtime.
+requires-python = ">=3.10"
+
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: System :: Systems Administration",
+]
+
+# Dependencies are deliberately NOT duplicated here. requirements.txt is the
+# single list, it is what the Dockerfile and CI install, and copying it into
+# this file would recreate the drift this file exists to remove. LWS is run
+# from a checkout (`python3 lws.py`, `python3 api.py`), not installed as a
+# distribution, so nothing needs the copy.
+
+[project.urls]
+Homepage = "https://github.com/fabriziosalmi/lws"
+Documentation = "https://fabriziosalmi.github.io/lws/"
+Issues = "https://github.com/fabriziosalmi/lws/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ flask-cors>=6.0.5,<7.0.0
 tqdm>=4.66.2,<5.0.0 # For progress bars in lws.py
 
 # Testing dependencies
-pytest>=7.4.0,<8.0.0
+pytest>=9.1.1,<10.0.0
 pytest-cov>=7.1.0,<8.0.0
 pytest-mock>=3.15.1,<4.0.0

--- a/tests/test_python_support.py
+++ b/tests/test_python_support.py
@@ -1,0 +1,132 @@
+"""
+The supported Python versions have to agree across the three files that state them.
+
+Before pyproject.toml existed, nothing declared what LWS supports and the three
+places that implied it had drifted apart:
+
+    README.md        "Python 3.6 or higher"      (untrue since 2021)
+    ci.yml matrix    3.9 to 3.13
+    Dockerfile       python:3.14-slim
+
+The 3.9 entry blocked every dependency update that had moved past it, and 3.14,
+the version actually shipped, was the one version nobody tested. Neither was
+visible without opening three files and comparing them by hand.
+
+These tests make that comparison automatic: `requires-python` in pyproject.toml
+is the declaration, and the CI matrix and the Dockerfile have to stay inside it.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+
+def _version(text: str) -> tuple[int, int]:
+    major, minor = text.split(".")[:2]
+    return int(major), int(minor)
+
+
+@pytest.fixture(scope="module")
+def declared_floor() -> tuple[int, int]:
+    """The (major, minor) floor from `requires-python` in pyproject.toml."""
+    # Read with a regex rather than a TOML parser: tomllib is stdlib only from
+    # 3.11, and the floor being checked here is 3.10.
+    match = re.search(
+        r'^requires-python\s*=\s*"(>=\s*\d+\.\d+)"',
+        PYPROJECT.read_text(encoding="utf-8"), re.M,
+    )
+    assert match, "pyproject.toml declares no requires-python."
+    spec = match.group(1)
+    match = re.fullmatch(r">=\s*(\d+\.\d+)", spec.strip())
+    assert match, (
+        f"requires-python is {spec!r}. These tests understand a simple '>=X.Y' "
+        "floor; if the policy has become more complex, teach them the new shape "
+        "rather than deleting them."
+    )
+    return _version(match.group(1))
+
+
+@pytest.fixture(scope="module")
+def matrix_versions() -> list[tuple[int, int]]:
+    """The python-version matrix from the CI workflow."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    matrix = workflow["jobs"]["test"]["strategy"]["matrix"]["python-version"]
+    return [_version(str(v)) for v in matrix]
+
+
+@pytest.fixture(scope="module")
+def dockerfile_version() -> tuple[int, int]:
+    """The Python version the shipped image is built from."""
+    match = re.search(r"^FROM\s+python:(\d+\.\d+)", DOCKERFILE.read_text(encoding="utf-8"), re.M)
+    assert match, "Dockerfile has no `FROM python:X.Y` line to check against."
+    return _version(match.group(1))
+
+
+def test_ci_matrix_starts_at_the_declared_floor(declared_floor, matrix_versions):
+    """
+    A matrix entry below the floor is not testing an old Python, it is blocking
+    updates: the dependencies this project pins refuse to install there.
+    """
+    below = [v for v in matrix_versions if v < declared_floor]
+    assert not below, (
+        f"CI tests Python {['.'.join(map(str, v)) for v in below]}, below the "
+        f"declared floor {'.'.join(map(str, declared_floor))}. Either raise the "
+        "matrix or lower requires-python, but do not let them disagree."
+    )
+    assert min(matrix_versions) == declared_floor, (
+        f"The lowest tested version is {'.'.join(map(str, min(matrix_versions)))} "
+        f"but the floor is {'.'.join(map(str, declared_floor))}. The floor is "
+        "supposed to be tested, otherwise it is a claim rather than a guarantee."
+    )
+
+
+def test_the_shipped_python_is_tested(matrix_versions, dockerfile_version):
+    """
+    The Dockerfile is how LWS actually runs. Its interpreter being absent from
+    the matrix is how 3.14 went untested while the image was built on it.
+    """
+    assert dockerfile_version in matrix_versions, (
+        f"The Dockerfile builds on Python {'.'.join(map(str, dockerfile_version))}, "
+        f"which is not in the CI matrix {['.'.join(map(str, v)) for v in matrix_versions]}. "
+        "The version shipped to users is the one that most needs a test run."
+    )
+
+
+def test_the_shipped_python_satisfies_the_floor(declared_floor, dockerfile_version):
+    assert dockerfile_version >= declared_floor, (
+        f"The Dockerfile builds on Python {'.'.join(map(str, dockerfile_version))}, "
+        f"below the declared floor {'.'.join(map(str, declared_floor))}."
+    )
+
+
+def test_classifiers_match_the_matrix(matrix_versions):
+    """
+    The classifiers are what PyPI and tooling read. They are easy to forget when
+    a version is added or dropped, and wrong metadata is worse than none.
+    """
+    declared = {
+        _version(m)
+        for m in re.findall(
+            r'"Programming Language :: Python :: (\d+\.\d+)"',
+            PYPROJECT.read_text(encoding="utf-8"),
+        )
+    }
+    assert declared == set(matrix_versions), (
+        f"Classifiers declare {sorted(declared)} but CI tests {sorted(set(matrix_versions))}."
+    )
+
+
+def test_the_interpreter_running_the_tests_satisfies_the_floor(declared_floor):
+    """A sanity check on the floor itself: it cannot exceed what CI runs on."""
+    assert sys.version_info[:2] >= declared_floor, (
+        f"These tests are running on Python {sys.version_info.major}.{sys.version_info.minor}, "
+        f"below the declared floor {'.'.join(map(str, declared_floor))}."
+    )


### PR DESCRIPTION
This is the follow-up to the floor question in #32, answered properly rather than by picking a number.

## The real problem was not 3.9 against 3.10

It was that **nothing in the repository declared what LWS supports.** Three files implied it, and they disagreed:

| | said |
|---|---|
| `README.md` | "Python 3.6 or higher" (untrue since 2021) |
| `ci.yml` matrix | 3.9 to 3.13 |
| `Dockerfile` | `python:3.14-slim` |

That is why the floor came up as a judgement call on every dependency bump, and why **3.14, the version actually shipped to users, was the one version nobody tested**. Answering "3.10" once would have left the same three files free to drift again next month.

## The declaration

`pyproject.toml` now carries `requires-python = ">=3.10"`, so `pip` refuses an unsupported interpreter up front instead of failing later with a dependency that will not resolve. Today someone on Debian 11 discovers the problem when `pip install -r requirements.txt` cannot find `requests`.

The floor is stated as a **policy rather than a decision to retake**: the CPython versions upstream still supports, dropping one as it reaches end of life. That removes the question rather than answering it once.

**Dependencies are deliberately not duplicated into `pyproject.toml`.** `requirements.txt` is the single list, it is what the Dockerfile and CI install, and copying it would recreate the exact drift this change exists to remove. LWS runs from a checkout, not as an installed distribution, so nothing needs the copy.

## The check

`tests/test_python_support.py` makes the comparison automatic instead of leaving it to whoever remembers to open three files:

- the CI matrix starts exactly at the declared floor (a floor that is not tested is a claim, not a guarantee)
- the Dockerfile's interpreter is in the matrix
- the Dockerfile's interpreter satisfies the floor
- the classifiers match the matrix

Verified that it catches both drifts that actually happened:

```
3.9 put back in the matrix   -> FAILED test_ci_matrix_starts_at_the_declared_floor
                                FAILED test_classifiers_match_the_matrix
Dockerfile moved to 3.15     -> FAILED test_the_shipped_python_is_tested
```

One detail worth naming: the tests read `requires-python` with a regex rather than `tomllib`, which is stdlib only from 3.11 and would not import on the 3.10 job the floor exists to protect. I caught that after writing it the obvious way.

```
103 passed
```

98 existing plus the 5 new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)